### PR TITLE
Fixed memory leak in CrossSocket.

### DIFF
--- a/Net/Net.CrossSocket.Base.pas
+++ b/Net/Net.CrossSocket.Base.pas
@@ -699,7 +699,7 @@ type
 
   TIoEventThread = class(TThread)
   private
-    FCrossSocket: ICrossSocket;
+    [Weak] FCrossSocket: ICrossSocket;
   protected
     procedure Execute; override;
   public
@@ -998,8 +998,8 @@ end;
 
 procedure TAbstractCrossSocket.AfterConstruction;
 begin
-  inherited AfterConstruction;
   StartLoop;
+  inherited AfterConstruction;
 end;
 
 procedure TAbstractCrossSocket.BeforeDestruction;


### PR DESCRIPTION
Before, TAbstractCrossSocket never destroyed because there is a circular reference with the class TIoEventThread, so I added the Weak. The change in AfterConstruction is because inside of it, after Inherited, RefCount decreases to 0, and calling StartLoop or any method after Inherited within AfterConstruction will be extremely dangerous, since any reference that increases within these methods, when decreasing and internally checking that the ReCount is 0, it will destroy the TAbstractCrossSocket before it even completely exits the AfterConstruction.