### PR TITLE
fixed: connection cannot be upgraded to websocket if Connection header is not exactlly "Upgrade"

### DIFF
--- a/Net/Net.CrossWebSocketServer.pas
+++ b/Net/Net.CrossWebSocketServer.pas
@@ -330,6 +330,9 @@ type
 
 implementation
 
+uses
+  StrUtils;
+
 { TCrossWebSocketConnection }
 
 constructor TCrossWebSocketConnection.Create(AOwner: ICrossSocket;
@@ -1043,8 +1046,8 @@ var
   LConnection: ICrossWebSocketConnection;
 begin
   LConnection := AConnection as ICrossWebSocketConnection;
-  if SameText(AConnection.Request.Header['Connection'], 'Upgrade')
-    and SameText(AConnection.Request.Header['Upgrade'], 'websocket') then
+  if ContainsText(AConnection.Request.Header['Connection'], 'Upgrade')
+    and ContainsText(AConnection.Request.Header['Upgrade'], 'websocket') then
   begin
     TCrossWebSocketConnection(LConnection).FIsWebSocket := True;
     _WebSocketHandshake(LConnection,


### PR DESCRIPTION
Demo application does not work with Firefox browser as the latter sends
  `Connection: keep-alive, Upgrade`
header rather than
  `Connection: Upgrade`
as IE or Chromium do.

[RFC 6455](https://tools.ietf.org/html/rfc6455#section-4.1) says
...
6.   The request MUST contain a |Connection| header field whose value
        MUST include the "Upgrade" token.
...
Also,
...
5.   The request MUST contain an |Upgrade| header field whose value
        MUST include the "websocket" keyword.
...

So, fix this. Test headers CONTAIN token but not EQUALS.