### PR TITLE
Fixed CrossHttpConsole demo without ssl

### DIFF
--- a/Net/Demos/CrossHttpConsole/CrossHttpConsole.dproj
+++ b/Net/Demos/CrossHttpConsole/CrossHttpConsole.dproj
@@ -117,7 +117,7 @@
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
         <SanitizedProjectName>CrossHttpConsole</SanitizedProjectName>
         <DCC_Define>__CROSS_SSL__;$(DCC_Define)</DCC_Define>
-        <DCC_UnitSearchPath>..\..;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
+        <DCC_UnitSearchPath>..\..;..\..\..\Utils;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Android)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;DBXInterBaseDriver;DataSnapFireDAC;tethering;bindcompfmx;FmxTeeUI;fmx;FireDACDBXDriver;dbexpress;IndyCore;dsnap;DataSnapCommon;bindengine;DataSnapClient;bindcompdbx;IndyIPCommon;IndyIPServer;IndySystem;fmxFireDAC;ibmonitor;FMXTee;DbxCommonDriver;ibxpress;xmlrtl;DataSnapNativeClient;ibxbindings;FireDACDSDriver;rtl;DbxClientDriver;CustomIPTransport;bindcomp;IndyIPClient;dbxcds;DataSnapProviderClient;dsnapxml;dbrtl;IndyProtocols;$(DCC_UsePackage)</DCC_UsePackage>

--- a/Net/Demos/CrossHttpConsole/uDM.pas
+++ b/Net/Demos/CrossHttpConsole/uDM.pas
@@ -198,14 +198,14 @@ end;
 
 procedure TDM.DataModuleCreate(Sender: TObject);
 begin
-  FHttpServer := TCrossHttpServer.Create(0, True);
-//  {$IFDEF __CROSS_SSL__}
+  FHttpServer := TCrossHttpServer.Create(0, {$IFDEF __CROSS_SSL__}True{$ELSE}False{$ENDIF});
+  {$IFDEF __CROSS_SSL__}
   if FHttpServer.SSL then
   begin
     FHttpServer.SetCertificate(SSL_SERVER_CERT);
     FHttpServer.SetPrivateKey(SSL_SERVER_PKEY);
   end;
-//  {$ENDIF}
+  {$ENDIF}
 //  FHttpServer.Addr := IPv4_ALL; // IPv4
 //  FHttpServer.Addr := IPv6_ALL; // IPv6
   FHttpServer.Addr := IPv4v6_ALL; // IPv4v6


### PR DESCRIPTION
Fixed CrossHttpConsole demo without ssl that was reported in issue #58