### PR TITLE
Comment out hardcoded FormatSettings

### DIFF
--- a/Utils/Utils.DateTime.pas
+++ b/Utils/Utils.DateTime.pas
@@ -882,7 +882,12 @@ begin
     FormatSettings.ShortMonthNames[I] := ShortMonthNamesEnglish[I];
 end;
 
+{
+Initialize Formatsettings in a component is not a good style.
+This can cause al kinds of trouble.
+FormatSettings is set automatically at start and this should be respected
+
 initialization
-  _InitDefaultFormatSettings;
+  _InitDefaultFormatSettings; }
 
 end.


### PR DESCRIPTION
I comment out the hard-coded change of Formatsettings.
This is not a good behavior of a component.

CrossSockets is used in our team and after latest update Devexpress DateControl behaves strange.
It set dates over 100 years back in time. It took some days to find out but this is what happens.

- FormatSettings is set in _InitDefaultFormatSettings
- Devexpress read the settings and cache the result internally
- Our application then set FormatSettings according our standard

Now when try to use the Devexpress DateEdit components and set date for ex. 15.6.2024 the result was very wrong. Like
12.1.1908. When Utils.DateTime.pas was removed from project everything works fine again.

Never ever do something like this in a component!

Regards