### PR TITLE
_SSL_print_error call _Log instead of Writeln

### DIFF
--- a/Net/Net.CrossSslSocket.OpenSSL.pas
+++ b/Net/Net.CrossSslSocket.OpenSSL.pas
@@ -368,8 +368,7 @@ var
 begin
   LError := _SSL_get_error(ARetCode);
   Result := SSL_is_fatal_error(LError);
-  if Result and IsConsole then
-    Writeln(Format(ATitle + ' error %d %s', [LError, ssl_error_message(LError)]));
+  _Log(ATitle + ' error %d %s (fatal: %s)', [LError, ssl_error_message(LError), BoolToStr(Result, True)]);
 end;
 
 procedure TCrossOpenSslConnection._Send(const ABuffer: Pointer;


### PR DESCRIPTION
I suppose this is a leftover from development. Logging SSL errors like others through the __Log_ method would help with catching errors.