### PR TITLE
Listen(port=0) - htons the port copied to the next addrinfo

### DIFF
--- a/Net/Net.CrossSocket.Epoll.pas
+++ b/Net/Net.CrossSocket.Epoll.pas
@@ -902,7 +902,7 @@ begin
 
       // 如果端口传入0，让所有地址统一用首个分配到的端口
       if (APort = 0) and (LAddrInfo.ai_next <> nil) then
-        Psockaddr_in(LAddrInfo.ai_next.ai_addr).sin_port := LListen.LocalPort;
+        Psockaddr_in(LAddrInfo.ai_next.ai_addr).sin_port := htons(LListen.LocalPort);
 
       LAddrInfo := PRawAddrInfo(LAddrInfo.ai_next);
     end;

--- a/Net/Net.CrossSocket.Iocp.pas
+++ b/Net/Net.CrossSocket.Iocp.pas
@@ -705,7 +705,7 @@ begin
 
       // 如果端口传入0，让所有地址统一用首个分配到的端口
       if (APort = 0) and (LAddrInfo.ai_next <> nil) then
-        LAddrInfo.ai_next.ai_addr.sin_port := LListen.LocalPort;
+        LAddrInfo.ai_next.ai_addr.sin_port := htons(LListen.LocalPort);
 
       LAddrInfo := PRawAddrInfo(LAddrInfo.ai_next);
     end;

--- a/Net/Net.CrossSocket.Kqueue.pas
+++ b/Net/Net.CrossSocket.Kqueue.pas
@@ -985,7 +985,7 @@ begin
 
       // 如果端口传入0，让所有地址统一用首个分配到的端口
       if (APort = 0) and (LAddrInfo.ai_next <> nil) then
-        Psockaddr_in(LAddrInfo.ai_next.ai_addr).sin_port := LListen.LocalPort;
+        Psockaddr_in(LAddrInfo.ai_next.ai_addr).sin_port := htons(LListen.LocalPort);
 
       LAddrInfo := PRawAddrInfo(LAddrInfo.ai_next);
     end;


### PR DESCRIPTION
When Listen(port=0) resolves to multiple addrinfos (typically IPv6 + IPv4) the first listener binds an ephemeral port, then that port is copied into the next addrinfo's sin_port so all listeners share it. But sin_port is in network byte order, while LListen.LocalPort is host order (the integer parsed out of getnameinfo's NI_NUMERICSERV string in TSocketAPI.ExtractAddrInfo), so without htons() the second listener binds a byte-swapped port -- the dual-stack port-0 listen no longer shares the port.

Fixed in all three backends (Kqueue/Epoll/Iocp). The Connect paths in the same units already use htons(ALocalPort), confirming intent.