### PR TITLE
Iocp.Send - guard AConnection.Close in the WSASend-failed path

### DIFF
--- a/Net/Net.CrossSocket.Iocp.pas
+++ b/Net/Net.CrossSocket.Iocp.pas
@@ -752,7 +752,8 @@ begin
     if Assigned(ACallback) then
       ACallback(AConnection, False);
 
-    AConnection.Close;
+    if Assigned(AConnection) then
+      AConnection.Close;
   end;
 end;
 


### PR DESCRIPTION
When WSASend fails synchronously (returns < 0 with an error other than WSA_IO_PENDING), the cleanup path freed the IO data, fired the failure callback, then called AConnection.Close unconditionally. In practice AConnection has been observed to be nil at that point, so the bare call AVs.

Guard the Close with Assigned(AConnection) so the failure path stays safe regardless of what the callback or earlier state did.