### PR TITLE
OpenSSL: fix use-after-free of encrypted send buffer in _SslSend

### DIFF
--- a/Net/Net.CrossSslSocket.OpenSSL.pas
+++ b/Net/Net.CrossSslSocket.OpenSSL.pas
@@ -595,7 +595,13 @@ begin
     if (LEncryptedData <> nil) then
     begin
       // 锁外发起异步发送, callback 内 CPS 继续推进 (新栈帧, 不在原栈上)
-      _Send(@LEncryptedData[0], Length(LEncryptedData),
+      // Use the TBytes overload so the buffer stays alive until the deferred
+      // send fires. The pointer overload does not copy and the callback closure
+      // does not capture LEncryptedData -- a use-after-free that's deterministic
+      // on macOS/Kqueue (allocator reuses the freed slot before transmit) and
+      // latent on Linux/Epoll and Windows/IOCP. Matches the canonical safe
+      // pattern documented in TCrossConnectionBase.SendBytes.
+      _Send(LEncryptedData,
         procedure(const AConnection: ICrossConnection; const ASuccess: Boolean)
         begin
           if not ASuccess then


### PR DESCRIPTION
Problem
-------
With the OpenSSL TLS client, the handshake completes but the first application-data SSL_read after sending fails with SSL_ERROR_SSL (empty error queue), and the connection drops. Reproducible and deterministic on macOS (Kqueue); latent on Linux (Epoll) and Windows (IOCP), where it usually works by luck.

Root cause
----------
TCrossOpenSslConnection._SslSend transmitted the encrypted data via the pointer overload _Send(@LEncryptedData[0], Length(LEncryptedData), cb). The backends' Send does not copy the buffer -- it queues the raw pointer and defers the actual transmit to the write-ready event. But LEncryptedData is a local TBytes that the callback closure does not capture, so it was freed when _SslSend returned, before the deferred send ran. The transmit then read freed memory.

When the allocator reuses that memory before transmit (deterministic on macOS), the client sends a corrupted TLS record; the peer can't decrypt it and replies with a fatal alert, surfacing as the failed SSL_read. The handshake is unaffected because handshake data is sent through the TBytes overload _Send(LHandshakeData), which keeps the buffer alive via closure capture.

Fix
---
Send the encrypted data through the TBytes overload as well, so the buffer is retained until the send callback fires.

This is the canonical safe pattern -- TCrossConnectionBase.SendBytes (Net.CrossSocket.Base.pas ~ line 1821) -- where the author explicitly documents the trap in a comment: SendBuf passes a raw address and does not increment refcount, so the caller must keep a local reference. A sweep of all relevant call sites confirms every other caller (HTTP server, WebSocket -> SendBytes, MbedTls backend) already follows the contract; _SslSend in the OpenSSL backend was the only violation.

Tested
------
HTTPS GET (372 KB body) -- PASS on Windows (IOCP), Linux (OpenSSL 3.0.13 / Epoll), macOS (OpenSSL 3.1.3 / Kqueue). macOS was failing deterministically before the change; no regression on the others.



Resolves #176