### PR TITLE
Fix swapped libssl/libcrypto names on macOS (SSL cannot initialise)

### DIFF
--- a/Net/Net.OpenSSL.pas
+++ b/Net/Net.OpenSSL.pas
@@ -3636,7 +3636,9 @@ begin
         'libcrypto.so.1.1',
         'libcrypto.so'
         {$ELSEIF DEFINED(MACOS)}
-        'libssl.dylib'
+        'libcrypto.3.dylib',
+        'libcrypto.1.1.dylib',
+        'libcrypto.dylib'
         {$ENDIF}
       ];
     end;
@@ -3812,7 +3814,7 @@ begin
   begin
     if (FLibSSL <> '') then
       LSslLibs := [FLibSSL]
-    else if (LIBCRYPTO_NAME <> '') then
+    else if (LIBSSL_NAME <> '') then
       LSslLibs := [LIBSSL_NAME]
     else
     begin
@@ -3830,7 +3832,9 @@ begin
         'libssl.so.1.1',
         'libssl.so'
         {$ELSEIF DEFINED(MACOS)}
-        'libcrypto.dylib'
+        'libssl.3.dylib',
+        'libssl.1.1.dylib',
+        'libssl.dylib'
         {$ENDIF}
       ];
     end;


### PR DESCRIPTION
`TSSLTools.LoadSslLibs` builds the macOS candidate list for **libcrypto** out of `'libssl.dylib'`, and the list for **libssl** out of `'libcrypto.dylib'` — the two are swapped.

The consequence is not cosmetic: `FSslLibHandle` ends up pointing at libcrypto, and the very first lookup off it

```pascal
@OPENSSL_init_ssl := GetSslLibProc(FSslLibHandle, 'OPENSSL_init_ssl');
```

raises `ESslInvalidProc` (`GetSslLibProc` raises when the symbol is missing, and libcrypto does not export any `SSL_*`). So SSL cannot initialise on macOS whenever OpenSSL is loaded dynamically — which is everywhere except iOS/Android, since `__SSL_STATIC__` is only defined for those two and the whole body of `LoadSslLibs` is under `{$IFNDEF __SSL_STATIC__}`.

### Changes

1. Swap the two macOS lists.
2. Add the versioned names, mirroring what the `LINUX` branch already does. OpenSSL 3 installs `libcrypto.3.dylib` / `libssl.3.dylib`; the unversioned symlinks are not always present.
3. Small copy/paste fix in the same routine — the static-name branch for `LSslLibs` tests `LIBCRYPTO_NAME` but assigns `LIBSSL_NAME`:

```pascal
    if (FLibSSL <> '') then
      LSslLibs := [FLibSSL]
-   else if (LIBCRYPTO_NAME <> '') then
+   else if (LIBSSL_NAME <> '') then
      LSslLibs := [LIBSSL_NAME]
```

This one is currently unreachable (both consts are `''` in dynamic builds, and the routine is compiled out in static ones), so it is just cleanup — happy to drop it from this PR if you would rather keep it focused.

### Checked

Compiles clean on Win64 (Delphi 37.0) via `Net.CrossWebSocketClient.pas`, which pulls in `Net.OpenSSL` — no new warnings or hints.