### PR TITLE
Fix use-after-free in TCrossConnectionBase.Close

### DIFF
--- a/Net/Net.CrossSocket.Base.pas
+++ b/Net/Net.CrossSocket.Base.pas
@@ -1722,11 +1722,17 @@ begin
 end;
 
 procedure TCrossConnectionBase.Close;
+var
+  LSelf: ICrossConnection;
 begin
   if (_SetConnectStatus(csClosed) = csClosed) then Exit;
 
   if (FSocket <> INVALID_SOCKET) then
   begin
+    // TriggerDisconnected removes this connection from the owner list and runs
+    // the user callback; either can drop our last reference. Keep one here so
+    // the object survives until InternalClose is done.
+    LSelf := Self;
     FOwner.TriggerDisconnected(Self);
     InternalClose;
     FSocket := INVALID_SOCKET;


### PR DESCRIPTION
```pascal
procedure TCrossConnectionBase.Close;
begin
  if (_SetConnectStatus(csClosed) = csClosed) then Exit;

  if (FSocket <> INVALID_SOCKET) then
  begin
    FOwner.TriggerDisconnected(Self);   // <-- may destroy Self
    InternalClose;                      // <-- on freed memory
    FSocket := INVALID_SOCKET;          // <-- on freed memory
  end;
end;
```

`Self` is an object reference being passed where an `ICrossConnection` is expected, so the compiler materialises a temporary interface reference and releases it **at the end of that statement**. Inside the call, `TriggerDisconnected` does

```pascal
FConnections.Remove(AConnection.UID);
...
LogicDisconnected(AConnection);
```

Either the list removal or the user callback can drop the last remaining reference to the connection. When that happens, the temporary is the only thing keeping the object alive, and it is gone by the time `InternalClose` and the `FSocket` reset run — both then touch freed memory.

Most call sites happen to be safe because they hold their own `LConnection: ICrossConnection` local, so this only bites on the paths where the caller's reference has already been dropped.

### Fix

Hold an `ICrossConnection` for the whole method. Two lines, no behaviour change on the paths that were already safe.

### How it showed up

`EUseAfterFreeError` in production (FastMM full-debug), reached through `TIocpCrossSocket.Send` -> `AConnection.Close` on an already-dead socket.

### Checked

Compiles clean on Win64 (Delphi 37.0) — no new warnings or hints.