### PR TITLE
WebSocket client: mask outgoing frames (RFC 6455 5.1)

### DIFF
--- a/Net/Net.CrossWebSocketClient.pas
+++ b/Net/Net.CrossWebSocketClient.pas
@@ -845,6 +845,7 @@ constructor TCrossWebSocket.Create(const AMgr: TCrossWebSocketMgr;
 begin
   FMgr := AMgr;
   FUrl := AUrl;
+  FMaskingKey := TCrossWebSocketParser.NewMaskingKey;
 
   FLock := TLock.Create;
 

--- a/Net/Net.CrossWebSocketParser.pas
+++ b/Net/Net.CrossWebSocketParser.pas
@@ -113,6 +113,7 @@ type
     class function MakeFrameData(AOpCode: Byte; AFin: Boolean; AMaskKey: Cardinal; AData: Pointer; ADataSize: UInt64): TBytes; static;
 
     class function NewSecWebSocketKey: string; static;
+    class function NewMaskingKey: Cardinal; static;
     class function MakeSecWebSocketAccept(const ASecWebSocketKey: string): string; static;
   end;
 
@@ -407,6 +408,16 @@ begin
   if not TryFillCryptRandomBytes(LKeyBytes[0], WS_KEY_SIZE) then
     raise ECrossSocket.Create('Failed to generate WebSocket key: CSPRNG unavailable');
   Result := TBase64Utils.Encode(LKeyBytes);
+end;
+
+class function TCrossWebSocketParser.NewMaskingKey: Cardinal;
+begin
+  // RFC 6455 S5.3: unpredictable, from a strong source of entropy.
+  // MakeFrameData reads 0 as "send unmasked", so never return it.
+  repeat
+    if not TryFillCryptRandomBytes(Result, SizeOf(Result)) then
+      raise ECrossSocket.Create('Failed to generate WebSocket masking key: CSPRNG unavailable');
+  until (Result <> 0);
 end;
 
 class function TCrossWebSocketParser.OpCodeToReqType(AOpCode: Byte): TWsMessageType;


### PR DESCRIPTION
`TCrossWebSocket.FMaskingKey` is never initialised, so it stays `0` unless the caller assigns `MaskingKey` by hand. And `MakeFrameData` reads `0` as *"do not mask"*:

```pascal
if (AMaskKey <> 0) then
  Result[1] := Result[1] or $80;   // MASK bit -- skipped
...
if (AMaskKey <> 0) then ... else
  Move(AData^, Result[LHeaderSize], LDataSize);   // payload sent in the clear
```

RFC 6455 5.1 requires every client-to-server frame to be masked, and says the server MUST close the connection on an unmasked one. So the client does not work against a compliant server out of the box.

The failure is confusing to diagnose, because the handshake is fine: `OnOpen` fires (101 + `Sec-WebSocket-Accept` validated), and only then does the peer drop the connection — right after the first frame is sent. What you see is a connect -> open -> close loop with no error anywhere.

### Fix

Add `TCrossWebSocketParser.NewMaskingKey` next to `NewSecWebSocketKey` — same unit, same CSPRNG (`Utils.CryptRandom`, already in its uses), same failure mode — and seed `FMaskingKey` from it in the constructor:

```pascal
class function TCrossWebSocketParser.NewMaskingKey: Cardinal;
begin
  repeat
    if not TryFillCryptRandomBytes(Result, SizeOf(Result)) then
      raise ECrossSocket.Create('Failed to generate WebSocket masking key: CSPRNG unavailable');
  until (Result <> 0);
end;
```

Callers that assign `MaskingKey` themselves are unaffected.

### One design note

The key is generated once per `TCrossWebSocket`, so a reconnect reuses it. Generating it in `Open` instead would give a fresh key per connection, which is closer to the spirit of 5.3 ("the masking key for a given frame MUST NOT be predicted by the server"). I kept it in the constructor to stay minimal — happy to move it if you prefer.

### Checked

Compiles clean on Win64 (Delphi 37.0) — no new warnings or hints. Verified live against a WSS endpoint that was previously closing the connection ~50 ms after the first frame: with a non-zero key the server accepts the frame and replies.