### PR TITLE
feat: add SetCipherList to override TLS 1.2 cipher list

### DIFF
--- a/Net/Net.CrossSslSocket.Base.pas
+++ b/Net/Net.CrossSslSocket.Base.pas
@@ -283,6 +283,9 @@ type
       const APassword: string = ''); virtual;
 
     procedure SetVerifyPeer(const AValue: Boolean); virtual;
+    { TLSOPT-2 (fork-only): override negotiated cipher list (TLS 1.2 and below).
+      ACipherList is an OpenSSL cipher-list string. Empty = keep _InitSslCtx default. }
+    procedure SetCipherList(const ACipherList: string); virtual; abstract;
 
     property Ssl: Boolean read GetSsl;
     property VerifyPeer: Boolean read GetVerifyPeer write SetVerifyPeer;
@@ -406,6 +409,7 @@ begin
     EndTlsConfigUpdate;
   end;
 end;
+
 
 procedure TCrossSslSocketBase.AddCACertificate(const ABuf: Pointer;
   const ASize: Integer);

--- a/Net/Net.CrossSslSocket.OpenSSL.pas
+++ b/Net/Net.CrossSslSocket.OpenSSL.pas
@@ -170,6 +170,8 @@ type
       const ASize: Integer); overload; override;
     procedure SetPrivateKey(const APKeyBuf: Pointer; const APKeyBufSize: Integer;
       const APassword: string); overload; override;
+    { Override the TLS 1.2 cipher list via SSL_CTX_set_cipher_list. }
+    procedure SetCipherList(const ACipherList: string); override;
   end;
 
 {$IFDEF CROSS_OPENSSL_SELFTEST}
@@ -1165,6 +1167,24 @@ begin
   BeginTlsConfigUpdate;
   try
     TSSLTools.SetPrivateKey(FSslCtx, APKeyBuf, APKeyBufSize, APassword);
+  finally
+    EndTlsConfigUpdate;
+  end;
+end;
+
+procedure TCrossOpenSslSocket.SetCipherList(const ACipherList: string);
+var
+  LAnsi: AnsiString;
+begin
+  if not Ssl or (FSslCtx = nil) or (ACipherList = '') then Exit;
+
+  BeginTlsConfigUpdate;
+  try
+    LAnsi := AnsiString(ACipherList);
+    if SSL_CTX_set_cipher_list(FSslCtx, PAnsiChar(LAnsi)) <> 1 then
+      raise ESsl.Create(
+        'SetCipherList: SSL_CTX_set_cipher_list rejected "' + ACipherList +
+        '" (no matching ciphers)');
   finally
     EndTlsConfigUpdate;
   end;


### PR DESCRIPTION
## Summary

- Adds `SetCipherList(const ACipherList: string)` as a `virtual; abstract` method on `TCrossSslSocketBase`
- Implements it in `TCrossOpenSslSocket` via `SSL_CTX_set_cipher_list`, wrapped in the existing `BeginTlsConfigUpdate`/`EndTlsConfigUpdate` pair
- Empty string is a no-op (leaves the context default untouched)
- An unrecognised cipher string raises `ESsl` at call site rather than silently falling back

## Motivation

Some deployments need to restrict TLS 1.2 to a custom cipher list (e.g. to comply with FIPS or PCI-DSS profiles) without forking the library. `SetCipherList` exposes the already-bound `SSL_CTX_set_cipher_list` through the public API.

## Notes

- TLS 1.3 cipher suites are controlled separately by `SSL_CTX_set_ciphersuites` (not changed here)
- The existing `SSL_CTX_set_cipher_list` binding in `Net.OpenSSL.pas` is reused — no new import needed
- Follows the same pattern as `SetCertificate`, `SetPrivateKey`, and `AddCACertificate`